### PR TITLE
change from ember-animated-outlet-mobile to liquid-fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ some info about some dependencies it uses.
 
 +  [ember-cli](http://iamstef.net/ember-cli/)
 +  [cordova](http://cordova.apache.org/docs/en/3.4.0/)
-+  [ember-animated-outlet](https://github.com/billysbilling/ember-animated-outlet)
++  [liquid-fire](https://github.com/ef4/liquid-fire)
 +  [moment.js](http://momentjs.com/docs/)
 
 # FAQ

--- a/blueprints/cordova-starter-kit/files/app/routes/application.js
+++ b/blueprints/cordova-starter-kit/files/app/routes/application.js
@@ -3,8 +3,7 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   actions: {
     back: function() {
-      Ember.AnimatedContainerView.enqueueAnimations({main: 'slideRight'});
-      history.go(-1);
+      history.back();
     },
 
     closeModal: function() {

--- a/blueprints/cordova-starter-kit/files/app/templates/application.hbs
+++ b/blueprints/cordova-starter-kit/files/app/templates/application.hbs
@@ -1,5 +1,5 @@
 <h1>Welcome to ember-cli-cordova!</h1>
 
-{{animated-outlet name="main"}}
+{{liquid-outlet name="main"}}
 
-{{outlet modal}}
+{{liquid-outlet modal}}

--- a/blueprints/cordova-starter-kit/files/app/transitions.js
+++ b/blueprints/cordova-starter-kit/files/app/transitions.js
@@ -1,0 +1,3 @@
+export default function() {
+
+}

--- a/blueprints/cordova-starter-kit/files/app/views/application.js
+++ b/blueprints/cordova-starter-kit/files/app/views/application.js
@@ -1,3 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.View.extend();

--- a/blueprints/cordova-starter-kit/files/app/views/index.js
+++ b/blueprints/cordova-starter-kit/files/app/views/index.js
@@ -1,3 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.View.extend();

--- a/blueprints/cordova-starter-kit/index.js
+++ b/blueprints/cordova-starter-kit/index.js
@@ -19,7 +19,7 @@ module.exports = {
   afterInstall: function() {
     return Promise.all([
       this.addPackageToProject('broccoli-sass'),
-      this.addPackageToProject('ember-animated-outlet-mobile'),
+      this.addPackageToProject('liquid-fire'),
     ]);
   }
 };


### PR DESCRIPTION
@jakecraige liquid-fire works really nice. You don't need to define empty views, you don't need to enqueue animations or use custom methods for transitions. All animations are defined in the app/transitions.js file, otherwise it just does a normal transition. 
