### PR TITLE
WIP: Production app reload

### DIFF
--- a/addon/initializers/download-assets.js
+++ b/addon/initializers/download-assets.js
@@ -1,0 +1,20 @@
+import deferReadiness from '../utils/defer-readiness';
+import redirect from '../utils/redirect';
+import downloadAssets from '../utils/download-assets';
+import startProxy from '../utils/start-proxy-server';
+
+export var initialize = function(url, container, app) {
+  return deferReadiness(app).then(function() {
+    downloadAssets(url).then(startProxy, function(err) {
+      return startProxy('.');
+    }).then(redirect);
+
+  }).finally(function() {
+    app.advanceReadiness();
+  });
+};
+
+export default {
+  name: 'cordova:download-assets',
+  initialize: initialize
+};

--- a/addon/utils/download-assets.js
+++ b/addon/utils/download-assets.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+
+var randomInt = function (min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+export default function downloadAssets(zipDownloadURL) {
+  return new Ember.RSVP.Promise(function(resolve, reject) {
+    window.requestFileSystem(LocalFileSystem.PERSISTENT, 0, function(fs) {
+      var rootURL = fs.root.toURL();
+
+      fs.root.getFile('app.zip', { create: true }, function(newFileEntry) {
+        var ft = new FileTransfer();
+
+        ft.download(zipDownloadURL, newFileEntry.toURL(), function(file) {
+          return newFileEntry.getParent(function(directoryEntry){
+            var destination = directoryEntry.toURL();
+
+            return zip.unzip(file.toURL(), destination, function(err) {
+              if(err !== 0) { reject(err); }
+              resolve(destination + 'bundle')
+            });
+          }, reject);
+        }, reject);
+      }, reject);
+    }, reject);
+  });
+}

--- a/app/initializers/download-assets.js
+++ b/app/initializers/download-assets.js
@@ -1,0 +1,19 @@
+import config from '../config/environment';
+import downloadInitializer from 'ember-cli-cordova/initializers/download-assets';
+
+var downloadAssets = downloadInitializer.initialize;
+
+export var initialize = function(container, app) {
+  if(typeof cordova === 'undefined' ||
+      config.environment !== 'production' ||
+      config.environment !== 'staging') {
+    return;
+  }
+
+  return downloadAssets(config.zipDownloadURL, container, app);
+};
+
+export default {
+  name: 'cordova:download-assets',
+  initialize: initialize
+};

--- a/lib/commands/bundle.js
+++ b/lib/commands/bundle.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  name: 'cordova:bundle',
+  aliases: ['cdv:bundle'],
+  description: 'Bundle the dist folder into a zip that the app can download and use',
+  works: 'insideProject',
+
+  availableOptions: [
+    { name: 'environment', type: String, default: 'staging' }
+  ],
+
+  run: function(options) {
+    return require('../tasks/bundle')(options.environment, this.project)();
+  }
+};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -3,5 +3,6 @@ module.exports = {
   'cordova:build':   require('./build'),
   'cordova:open':    require('./open'),
   'cordova:prepare': require('./prepare'),
-  'cordova:archive': require('./archive')
+  'cordova:archive': require('./archive'),
+  'cordova:bundle':  require('./bundle')
 };

--- a/lib/tasks/bundle.js
+++ b/lib/tasks/bundle.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var runCommand = require('../utils/run-command');
+var Promise    = require('../ext/promise');
+var path       = require('path');
+var linkEnv    = require('../tasks/link-environment');
+var ui         = require('../ui');
+var chalk      = require('chalk');
+var archiver   = require('archiver');
+var fs         = require('fs');
+
+module.exports = function(env, project) {
+  var emberCommand = 'ember build --environment ' + env;
+
+  var emberMsg   = 'Building ember project for environment ' + env;
+  var emberBuild = runCommand(emberCommand, emberMsg, {
+    cwd: project.root
+  });
+
+  var doZip = function() {
+    var zipMsg   = 'Zipping dist folder into public/bundle.zip';
+    ui.start(chalk.green(zipMsg));
+
+    return new Promise(function(resolve, reject) {
+      var output = fs.createWriteStream(path.join(project.root, 'public', 'bundle.zip'));
+      var archive = archiver('zip');
+      output.on('close', resolve);
+      archive.on('error', reject);
+      archive.pipe(output);
+      archive.bulk([
+        { expand: true, cwd: path.join(project.root, 'dist'), src: ['**/*'] }
+      ]).finalize();
+    });
+  }
+
+
+  return function(){
+    return linkEnv(project)().then(emberBuild).then(doZip);
+  };
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "archiver": "^0.11.0",
     "chalk": "^0.4.0",
     "findup-sync": "^0.1.3",
     "fs-extra": "^0.8.1",


### PR DESCRIPTION
This pull request adds support for having your app deployed to the app stores, and pushing an update of your assets without an app store push. It will work by downloading a zip file and unzipping it to a directory in the app. It will then attempt to load that file as the index for the app. 

To do this we will need to build an update server to manage the state of each application. My initial thoughts are that we could store the application version in the environment.js and then send that as a header to the update server. It would then decide whether or not the app needs an update and send that down.


- [x] Download and unzip assets
- [ ] Knowledge of local version for sending to API
- [ ] Update server API
