### PR TITLE
fix cordova-init create project failure and platform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,15 @@ ember generate cordova-init com.reverse.domain
 ```
 
 This will generate a base cordova iOS app and store it within the `cordova/`
-directory. If you would like to add other platforms, you can run the 
-`ember cordova` command:
+directory. If you want to generate an android project instead you must pass in
+the `--platform` option. That would look like this:
+
+```sh
+ember generate cordova-init com.reverse.domain --platform=android
+```
+
+If you would like to add more platforms, you can run the 
+`ember cordova` command after the project is initialized:
 
 ```sh
 ember cordova platform add android

--- a/blueprints/cordova-init/index.js
+++ b/blueprints/cordova-init/index.js
@@ -14,7 +14,7 @@ module.exports = {
 
   afterInstall: function(options) {
     this.options = options.entity.options;
-    this.options.platform = this.options.platform || 'ios';
+    this.options.platform = options.platform || 'ios';
 
     projectWithConfig(this.project, options.entity.name);
 

--- a/lib/tasks/create-cordova-project.js
+++ b/lib/tasks/create-cordova-project.js
@@ -1,11 +1,13 @@
 'use strict';
 
-var cordova = require('./cordova');
+var runCommand = require('../utils/run-command');
+var path       = require('path');
 
 module.exports = function(project) {
-  var config = project.cordovaConfig;
+  var config  = project.cordovaConfig;
+  var command = 'cordova create cordova ' + config.id + ' ' + config.name;
 
-  var args = ['create', 'cordova', config.id, config.name];
-
-  return cordova(args, project);
+  return runCommand(command, 'Creating Cordova project', {
+    cwd: project.root
+  });
 };

--- a/node-tests/unit/tasks/create-cordova-project-test.js
+++ b/node-tests/unit/tasks/create-cordova-project-test.js
@@ -6,12 +6,10 @@ describe('Tasks - Create cordova project', function() {
 
   it('creates the proper command', function() {
     var createProject = proxyquire('../../lib/tasks/create-cordova-project', {
-      './cordova': proxyquire('../../lib/tasks/cordova', {
-        '../utils/run-command': function(command) {
-          expect(command).to.eql('cordova create cordova com.poetic.test-app TestApp');
-          return resolveFn;
-        }
-      })
+      '../utils/run-command': function(command) {
+        expect(command).to.eql('cordova create cordova com.poetic.test-app TestApp');
+        return resolveFn;
+      }
     });
 
     return createProject(project)();
@@ -19,12 +17,10 @@ describe('Tasks - Create cordova project', function() {
 
   it('should execute in proper folder', function() {
     var createProject = proxyquire('../../lib/tasks/create-cordova-project', {
-      './cordova': proxyquire('../../lib/tasks/cordova', {
-        '../utils/run-command': function(_, _, options) {
-          expect(options.cwd).to.equal('project-root/cordova');
-          return resolveFn;
-        }
-      })
+      '../utils/run-command': function(_, _, options) {
+        expect(options.cwd).to.equal('project-root');
+        return resolveFn;
+      }
     });
 
     return createProject(project)();


### PR DESCRIPTION
The create command is the one cordova command that _shouldn't_ run in the cordova directory and I had it set to do that.

It also fixes the platform option no longer working on init. I guess ember-cli changes the api for options. Either way, it works now. 

refs #74 
