### PR TITLE
use replace to redirect, and delay replace to fix NSURLErrorDomain

### DIFF
--- a/addon/utils/redirect.js
+++ b/addon/utils/redirect.js
@@ -1,5 +1,9 @@
+import Ember from 'ember';
+
 export default function(url) {
   if(window.location.href.indexOf('file://') > -1) {
-    window.location.href = url;
+    Ember.run.later(function() {
+      window.location.replace(url);
+    }, 50);
   }
 }


### PR DESCRIPTION
fixes #102
Seems lots of people have experienced this
https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=cordova+redirect+NSURLErrorDomain

The delay is pretty arbitrary. A simple run.later without a delay doesn't work.
So I bumped it up to where it did work, on my iPhone 6+. I'm not sure if device
performance plays a role in this so if you are still having problems, please
report it so we can up it.
