### PR TITLE
[FEATURE] Allow better hybrid builds (fixes #114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+.idea

--- a/blueprints/cordova-init/files/config/environment.js
+++ b/blueprints/cordova-init/files/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: '<%= modulePrefix %>',
     environment: environment,
     baseURL: '/',
-    locationType: 'hash',
+    defaultLocationType: 'auto',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/blueprints/cordova-starter-kit/files/config/environment.js
+++ b/blueprints/cordova-starter-kit/files/config/environment.js
@@ -17,7 +17,7 @@ module.exports = function(environment) {
     modulePrefix: '<%= modulePrefix %>',
     environment: environment,
     baseURL: '/',
-    locationType: 'hash',
+    defaultLocationType: 'auto',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,9 +62,12 @@ ember generate cordova-starter-kit
 ## Developing The App
 
 Once your project is set up, you're ready to start developing. We've tried to
-keep the experience as similar to ember-cli as possible.
+keep the experience as similar to ember-cli as possible. You just need to move
+your `locationType` setting in `config/environment.js` to `defaultLocationType`
+so that it'd be used when not building for cordova (cordova needs `hash` as
+`locationType`).
 
-You can simply run the `serve` command and begin
+Then you can simply run the `serve` command and begin
 
 ```sh
 ember serve
@@ -77,6 +80,16 @@ quickest feedback loop, debugging tools and best experience.
 The one drawback to this is that any cordova plugins you use will not work in
 the browser. This means that when you want to test the functionality of
 a plugin, you will need to load the app up on a simulator or device.
+
+When you need to serve or build files for a browser environment (not for cordova)
+be sure to override the `EMBER_CLI_CORDOVA` environment variable to set it to a
+falsy value (`0`, `no`, `off` or `false`). It'll allow you to use `locationType`
+as specified in `defaultLocationType` and will not inject the `cordova.js`
+script tag.
+
+```sh
+EMBER_CLI_CORDOVA=0 ember serve
+```
 
 ### Running The App On A Simulator Or Device
 

--- a/index.js
+++ b/index.js
@@ -1,51 +1,70 @@
 'use strict';
 
-var path      = require('path');
-var fs        = require('fs');
-var commands  = require('./lib/commands');
+var path = require('path');
+var fs = require('fs');
+var commands = require('./lib/commands');
 var postBuild = require('./lib/tasks/post-build');
-var defaults  = require('lodash').defaults;
-var chalk     = require('chalk');
+var defaults = require('lodash').defaults;
+var chalk = require('chalk');
+
 
 module.exports = {
   name: 'ember-cli-cordova',
 
-  contentFor: function(type) {
-    if(type === 'body') {
+  _isTargetCordova: function () {
+    return !process.env.EMBER_CLI_CORDOVA ||
+      ['0', 'off', 'false', 'no'].indexOf(process.env.EMBER_CLI_CORDOVA.toLowerCase()) === -1;
+  },
+
+  config: function (env, config) {
+    var conf = {isCordovaBuild: this._isTargetCordova()};
+    if (conf.isCordovaBuild && env !== 'test') {
+      if (config.locationType && config.locationType !== 'hash') {
+        throw new Error('ember-cli-cordova: You must specify the locationType as \'hash\' in your environment.js or rename it to defaultLocationType.');
+      }
+      conf.locationType = 'hash';
+    }
+    else if (!conf.locationType) {
+      conf.locationType = config.defaultLocationType || 'auto';
+    }
+    conf.cordova = defaults(config.cordova || {}, {
+      liveReload: {
+        enabled:  false,
+        platform: 'ios'
+      }
+    });
+    return conf;
+  },
+
+  contentFor: function (type) {
+    if (this._isTargetCordova() && type === 'body') {
       return '<script src="cordova.js"></script>';
     }
   },
 
-  includedCommands: function() {
+  includedCommands: function () {
     return commands;
   },
 
-  cdvConfig: function() {
-    var config = this.project.config('development');
+  cdvConfig: function () {
+    return this.project.config(process.env.EMBER_ENV || 'development').cordova;
+  },
 
-    if (config.environment !== 'test' && config.locationType !== 'hash') {
-      throw new Error('ember-cli-cordova: You must specify the locationType as \'hash\' in your environment.js');
+  postBuild: function () {
+    if (this._isTargetCordova()) {
+      return postBuild(this.project, this.cdvConfig())();
     }
-
-    var cdvConfig = defaults(config.cordova || {}, {
-      liveReload: {
-        enabled: false,
-        platform: 'ios'
-      }
-    });
-
-    return cdvConfig;
+    else {
+      return function () {
+      };
+    }
   },
 
-  postBuild: function() {
-    return postBuild(this.project, this.cdvConfig())();
-  },
-
-  treeForPublic: function(tree) {
+  treeForPublic: function (tree) {
     var config = this.cdvConfig();
 
-    if(config.liveReload.enabled) {
-      if(!config.liveReload.platform) {
+    if (this._isTargetCordova() && config.liveReload.enabled) {
+      if (!config.liveReload.platform) {
         throw new Error('ember-cli-cordova: You must specify a liveReload.platform in your environment.js');
       }
 
@@ -54,30 +73,32 @@ module.exports = {
 
       if (config.liveReload.platform === 'ios') {
         pluginsPath = path.join(platformsPath, 'ios', 'www');
-      } else if (config.liveReload.platform === 'android') {
+      }
+      else if (config.liveReload.platform === 'android') {
         pluginsPath = path.join(platformsPath, 'android', 'assets', 'www');
-      } else {
+      }
+      else {
         pluginsPath = path.join(platformsPath, config.liveReload.platform);
       }
 
       var files = ['cordova.js', 'cordova_plugins.js'];
 
-      files.forEach(function(file) {
+      files.forEach(function (file) {
         var filePath = path.join(pluginsPath, file);
-        if(!fs.existsSync(filePath)) {
+        if (!fs.existsSync(filePath)) {
           var err = new Error('ember-cli-cordova: ' + filePath + ' did not exist. It is required for Device LiveReload to work.');
           err.stack = null;
           throw err;
         }
       });
 
-      if(fs.existsSync(path.join(pluginsPath, 'plugins'))) {
+      if (fs.existsSync(path.join(pluginsPath, 'plugins'))) {
         files.push('plugins/*');
       }
 
       var pluginsTree = this.pickFiles(this.treeGenerator(pluginsPath), {
-        srcDir: '/',
-        files: files,
+        srcDir:  '/',
+        files:   files,
         destDir: '/'
       });
 

--- a/node-tests/helpers/_helper.js
+++ b/node-tests/helpers/_helper.js
@@ -1,6 +1,9 @@
 global.expect = require('chai').expect;
 global.sinon  = require('sinon');
 
+// be sure to not have any env variable set
+delete process.env.EMBER_CLI_CORDOVA;
+
 // Requiring a relative path will need to be relative to THIS file path
 global.proxyquire = require('proxyquire');
 
@@ -17,4 +20,4 @@ global.newProject = function() {
     },
     root: 'project-root'
   }
-}
+};

--- a/node-tests/unit/addon-test.js
+++ b/node-tests/unit/addon-test.js
@@ -1,38 +1,75 @@
 var addon = require('../../index');
 
-function expectWithConfig(config) {
-  addon.project = {
-    config: function() {
-      return config;
-    }
-  };
-
-  return expect(addon.cdvConfig.bind(addon));
+function expectWithConfig(config, env, call) {
+  if (call) {
+    return expect(addon.config(env || 'development', config));
+  }
+  else {
+    return expect(addon.config.bind(addon, env || 'development', config));
+  }
 }
 
 var errRegex = /ember-cli-cordova: You must specify the locationType as 'hash' in your environment\.js/;
 
-describe('Addon', function() {
-  describe('config', function() {
-    describe('validates location type', function() {
-      it('should throw Error when auto', function() {
+describe('Addon', function () {
+  describe('config', function () {
+    var savedEnvVar;
+
+    beforeEach(function () {
+      savedEnvVar = process.env.EMBER_CLI_CORDOVA;
+    });
+
+    afterEach(function () {
+      process.env.EMBER_CLI_CORDOVA = savedEnvVar;
+    });
+
+    describe('validates location type', function () {
+      it('should throw Error when auto', function () {
         expectWithConfig({
           locationType: 'auto'
         }).to.throw(Error, errRegex);
       });
 
-      it('should not throw an error when hash', function() {
+      it('should not throw an error when hash', function () {
         expectWithConfig({
           locationType: 'hash'
         }).to.not.throw(Error, errRegex);
       });
 
-      it('should not throw an error with auto in test environment', function() {
+      it('should not throw an error with auto in test environment', function () {
         expectWithConfig({
-          environment: 'test',
+          locationType: 'auto'
+        }, 'test').to.not.throw(Error, errRegex);
+      });
+
+      it('should not throw an error when the env var is set to 0', function () {
+        process.env.EMBER_CLI_CORDOVA = '0';
+        expectWithConfig({
           locationType: 'auto'
         }).to.not.throw(Error, errRegex);
       });
     });
+
+    describe('should replace the locationType', function () {
+      it('should use the defaultLocationType when building for test', function () {
+        expectWithConfig({
+          defaultLocationType: 'auto'
+        }, 'test', true).to.have.property('locationType', 'auto');
+      });
+
+      it('should use the defaultLocationType when the env var is set to 0', function () {
+        process.env.EMBER_CLI_CORDOVA = '0';
+        expectWithConfig({
+          defaultLocationType: 'auto'
+        }, null, true).to.have.property('locationType', 'auto');
+      });
+
+      it('should use hash as locationType', function () {
+        expectWithConfig({
+          defaultLocationType: 'auto'
+        }, null, true).to.have.property('locationType', 'hash');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Added `EMBER_CLI_CORDOVA` environment variable defaulting to true. If set to false, any cordova related injections/magic will not happen, allowing to serve and build for a browser target instead of for cordova.

- [x] removes the failing to load `cordova.js` script if the build target isn't cordova
- [x] allow `locationType` to something else than `hash` when not building for cordova
- [x] added `defaultLocationType` to be used as `locationType` when not building for cordova
- [x] added unit tests
- [x] added documentation

This is an attempt to fix the enhancements explained in #114