### PR TITLE
Fix wrong locationType on test ENV

### DIFF
--- a/blueprints/cordova-init/files/config/environment.js
+++ b/blueprints/cordova-init/files/config/environment.js
@@ -35,7 +35,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.baseURL = '/';
-    ENV.locationType = 'auto';
+    ENV.locationType = 'none';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;


### PR DESCRIPTION
Cordova init blueprint shouldn't change test locationType to "auto". To be able to run the test on the browser it needs to be "none".

Here is the ember-cli default config for locationType on test ENV: https://github.com/ember-cli/ember-cli/blob/v0.1.12/blueprints/app/files/config/environment.js#L33