### PR TITLE
Update android versionCode when run cordova:archive

### DIFF
--- a/lib/tasks/archive.js
+++ b/lib/tasks/archive.js
@@ -16,7 +16,6 @@ module.exports = function(version, options, project) {
   var platform = options.platform || 'ios';
   var build   = require('./build')(options.environment, platform, project);
 
-
   if(platform === 'ios') {
     var iosPath        = path.join(project.root, 'cordova', 'platforms/ios');
     var archiveCommand = 'xcodebuild -scheme ' + config.name + ' archive';
@@ -24,6 +23,15 @@ module.exports = function(version, options, project) {
     archiveProject = runCommand(archiveCommand, archiveMessage, {
       cwd: iosPath
     });
+  }
+
+  if(platform === 'android' && version) {
+    var __updateXml = updateXml;
+
+    updateXml = function () {
+      var androidVersionCode = require('./update-config-xml-android-version-code')(project)
+      return __updateXml().then(androidVersionCode)
+    }
   }
 
   var commitCommand = 'git add . && git commit -m "archive version: '

--- a/lib/tasks/archive.js
+++ b/lib/tasks/archive.js
@@ -29,8 +29,8 @@ module.exports = function(version, options, project) {
     var __updateXml = updateXml;
 
     updateXml = function () {
-      var androidVersionCode = require('./update-config-xml-android-version-code')(project)
-      return __updateXml().then(androidVersionCode)
+      var androidVersionCode = require('./update-config-xml-android-version-code')(project);
+      return __updateXml().then(androidVersionCode);
     }
   }
 

--- a/lib/tasks/update-config-xml-android-version-code.js
+++ b/lib/tasks/update-config-xml-android-version-code.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs      = require('fs');
-var path = require('path');
+var path    = require('path');
 var Promise = require('../ext/promise');
 
 var versionCodeRegex = /(android-versionCode=\")[\d.]+(\")/;
@@ -23,10 +23,10 @@ module.exports = function(project) {
           return this.xmlReplace(versionCodeRegex, versionCode, xml);
         })().then(resolve, reject);
       } else {
-        reject()
+        reject();
       }
     } catch (e) {
-      reject(e)
+      reject(e);
     }
   });
 };

--- a/lib/tasks/update-config-xml-android-version-code.js
+++ b/lib/tasks/update-config-xml-android-version-code.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var fs      = require('fs');
+var path = require('path');
+var Promise = require('../ext/promise');
+
+var versionCodeRegex = /(android-versionCode=\")[\d.]+(\")/;
+var versionCodeMatch = /android-versionCode=\"([\d.])+\"/;
+
+module.exports = function(project) {
+  return new Promise(function(resolve, reject){
+    try {
+      var cordovaPath = path.join(project.root, 'cordova');
+      var configPath = path.join(cordovaPath, 'config.xml');
+      var xml = fs.readFileSync(configPath, { encoding: 'utf8' });
+
+      var match = xml.match(versionCodeMatch);
+      if(match) {
+        var versionCode = (parseInt(match[1], 10)) + 1;
+        var message     = 'Update config.xml with android-versionCode ' + versionCode;
+
+        return require('./modify-xml')(message, cordovaPath, function(xml) {
+          return this.xmlReplace(versionCodeRegex, versionCode, xml);
+        })().then(resolve, reject);
+      } else {
+        reject()
+      }
+    } catch (e) {
+      reject(e)
+    }
+  });
+};


### PR DESCRIPTION
Like android documentation:

```
android:versionCode — An integer value that represents the version of the application 
code, relative to other versions.
The value is an integer so that other applications can programmatically 
evaluate it, for example to check an upgrade or downgrade relationship. 
You can set the value to any integer you want, however you should make 
sure that each successive release of your application uses a greater value. 
The system does not enforce this behavior, but increasing the value with 
successive releases is normative.
Typically, you would release the first version of your application with 
versionCode set to 1, then monotonically increase the value with each release, 
regardless whether the release constitutes a major or minor release. 
This means that the android:versionCode value does not necessarily 
have a strong resemblance to the application release version that is visible 
to the user (see android:versionName, below). Applications and publishing 
services should not display this version value to users.
```

Now `ember cordova:archive` update android versionCode if **android-versionCode** is configured in config.xml
