### PR TITLE
Add support for the browser platform

### DIFF
--- a/blueprints/cordova-init/files/gitignore
+++ b/blueprints/cordova-init/files/gitignore
@@ -42,3 +42,7 @@ cordova/platforms/wp8/www
 cordova/platforms/wp8/.staging
 cordova/platforms/wp8/*.suo
 cordova/platforms/wp8/*.csproj.user
+
+#browser
+cordova/platforms/browser/build
+cordova/platforms/browser/www

--- a/index.js
+++ b/index.js
@@ -75,6 +75,9 @@ module.exports = {
       if (config.liveReload.platform === 'ios') {
         pluginsPath = path.join(platformsPath, 'ios', 'www');
       }
+      else if (config.liveReload.platform === 'browser') {
+        pluginsPath = path.join(platformsPath, 'browser', 'www');
+      }
       else if (config.liveReload.platform === 'android') {
         pluginsPath = path.join(platformsPath, 'android', 'assets', 'www');
       }


### PR DESCRIPTION
Cordova has also a platform for the browser. This PR only adds some changes to the `.gitignore` and enables live reload for the browser. 