### PR TITLE
Fix deprecation en 1.13 canary

### DIFF
--- a/app/templates/cdv-generic-nav-bar.hbs
+++ b/app/templates/cdv-generic-nav-bar.hbs
@@ -1,7 +1,7 @@
 {{#if nav.leftButton.text}}
   <button {{action 'leftButton'}}>
     {{#if nav.leftButton.icon}}
-      <i {{bind-attr class=":icon nav.leftButton.icon"}}></i>
+      <i class="icon {{nav.rightButton.icon}}"></i>
     {{/if}}
     {{nav.leftButton.text}}
   </button>
@@ -16,7 +16,7 @@
 {{#if nav.rightButton.text}}
   <button {{action 'rightButton'}}>
     {{#if nav.rightButton.icon}}
-      <i {{bind-attr class=":icon nav.rightButton.icon"}}></i>
+      <i class="icon {{nav.rightButton.icon}}"></i>
     {{/if}}
     {{nav.rightButton.text}}
   </button>


### PR DESCRIPTION
DEPRECATION: The `bind-attr` helper ('app/templates/cdv-generic-nav-bar.hbs' @ L4:C11) is deprecated in favor of HTMLBars-style bound attributes.