### PR TITLE
Implementing fast live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Please see our Getting Started guide
 + `ember cordova:prepare` needs to be run after cloning a project
 + `ember cordova` Passes commands(plugin(s), platform(s), run, emulate) and arguments to the cordova command
 + `ember help` ember cli help with a section for addon provided commands as well
++ `ember s --host=<ip>` starts ember server with live reload. Check the Getting Started guide for further instructions
 
 # Docs
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 This guide will walk you through setting up your first app with
-ember-cli-cordova. 
+ember-cli-cordova.
 
 ## Prerequisites
 
@@ -22,9 +22,9 @@ After that's set up, we need to add the ember-cli-cordova addon to the applicati
 ember install ember-cli-cordova
 ```
 
-Ember cli-cordova requires cordova. If you don't have cordova, use this line to install it. 
+Ember cli-cordova requires cordova. If you don't have cordova, use this line to install it.
 
-``` 
+```
 npm install -g cordova
 ```
 
@@ -135,19 +135,21 @@ now](https://github.com/poetic/ember-cli-cordova/pull/56).
 Livereload is currently disabled by default and will need to be turned on in
 your `config/environment`. To enable it, set `cordova.liveReload.enabled` to
 true, and set `cordova.liveReload.platform` to the platform you will be running
-the app on.
+the app on. Disable `cordova.rebuildOnChange` to enable fast live reload using
+the built-in live reloading mechanisms of Ember CLI.
 
-**A few things to be aware of**
+Now that you have configured livereload, you just need to run the ember server normally,
+using the traditional command, with only one difference: you need to specify the host to your
+LAN IP address (something like 192.168.0.3), so the emulator or a device picks up the correct page
+and livereload works.
 
-- You will need to rebuild with 'ember cordova:build' when you make changes to the
-  environment config.
-- When you add/remove/update plugins or native code you will also need to run
-  the `ember cordova:build`.
-- You will need to set the `emberUrl` in the config if you are running the app
-  on a device that is not on the same computer or if your ember server is on
-  a different port. It defaults to `http://localhost:4200`. The reason for this
-  is that when the app starts up, it redirects to the url your ember server is
-  running on so it must be set correctly.
-- Livereload is a fairly new feature in ember-cli-cordova and we are really
-  excited about it. If you have any trouble with it please submit an issue or PR
-  so that we can resolve it.
+```
+ember s --host=<your_lan_ip_address>
+```
+
+Again, like already said, this isn't rebuilding cordova every time
+you make a change, and there are some things you should be aware that needs the server
+to be restarted in order to cordova to rebuild.
+
+- When making changes to the environment config.
+- When you add/remove/update plugins or native code.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var path = require('path');
 var fs = require('fs');
 var commands = require('./lib/commands');
 var postBuild = require('./lib/tasks/post-build');
-var defaults = require('lodash').defaults;
+var _ = require('lodash');
+_.defaults = require('merge-defaults');
 var chalk = require('chalk');
 var mergeTrees = require('broccoli-merge-trees');
 var Funnel = require('broccoli-funnel');
@@ -28,10 +29,17 @@ module.exports = {
     else if (!conf.locationType) {
       conf.locationType = config.defaultLocationType || 'auto';
     }
-    conf.cordova = defaults(config.cordova || {}, {
+
+    /**
+     * Need defaultsDeep here instead of just `defaults` since we
+     * have a object as default option, nd that would not be picked...
+     */
+    conf.cordova = _.defaults(config.cordova || {}, {
       liveReload: {
         enabled:  false,
-        platform: 'ios'
+        platform: 'ios',
+        hostIP: process.env.CORDOVA_HOST_IP,
+        hostPort: process.env.CORDOVA_HOST_PORT
       }
     });
     return conf;
@@ -58,7 +66,7 @@ module.exports = {
     var options = this.cdvConfig();
 
     if (this._isTargetCordova() && this.enablePostBuild && this.firstBuild && options.liveReload !== undefined && options.liveReload.enabled) {
-      var func = postBuild(this.project, options, this.host, this.port, this.firstBuild);
+      var func = postBuild(this.project, options, this.firstBuild);
       // if the only thing we want is the live reload, no
       // need to re-build everytime, but we need to modify the xml
       // so this variable will help us only build one time. After that
@@ -139,8 +147,6 @@ module.exports = {
    * production.
    */
   serverMiddleware: function(config) {
-    this.host = config.options.host;
-    this.port = config.options.port;
     this.enablePostBuild = true;
   }
 };

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ module.exports = {
       var func = postBuild(this.project, options, this.host, this.port, this.firstBuild);
       // if the only thing we want is the live reload, no
       // need to re-build everytime, but we need to modify the xml
-      // so
+      // so this variable will help us only build one time. After that
+      // Ember CLI's live reload will work fine
       if (!options.rebuildOnChange) {
         this.firstBuild = false;
       }
@@ -128,6 +129,15 @@ module.exports = {
   isDevelopingAddong: function() {
     return true;
   },
+  /**
+   * We'll use this hook to gather the information
+   * we need to provide fast live reloads.
+   *
+   * PostBuild should really only be called when live
+   * reloading, cause it just compiles and emulates
+   * and don't think we need it when building for
+   * production.
+   */
   serverMiddleware: function(config) {
     this.host = config.options.host;
     this.port = config.options.port;

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -12,6 +12,17 @@ module.exports = function(env, platform, project) {
     cwd: project.root
   });
 
+  var config = project.cordovaConfig;
+  var message = 'Updating config.xml to disable live reload (if applicable)';
+  var cordovaPath = path.join(project.root, 'cordova');
+  var contentSrcRegex = /(src=\")[\w\.\d\:\/]+(\")/;
+
+  var m = require('./modify-xml')(message, cordovaPath, function(xml) {
+    xml = this.xmlReplace(contentSrcRegex, "index.html", xml);
+
+    return xml;
+  });
+
   var cdvCommand = 'cordova build ' + platform;
 
   if (env !== 'development') {
@@ -24,6 +35,6 @@ module.exports = function(env, platform, project) {
   });
 
   return function(){
-    return linkEnv(project)().then(emberBuild).then(cdvBuild);
+    return linkEnv(project)().then(m()).then(emberBuild).then(cdvBuild);
   };
 };

--- a/lib/tasks/modify-xml.js
+++ b/lib/tasks/modify-xml.js
@@ -26,6 +26,8 @@ module.exports = function(message, root, replaceFn) {
         xml = replaceFn.call(replaceObject, xml);
 
         fs.writeFileSync(configPath, xml);
+
+        ui.stop();
         resolve();
 
       } catch(e) {

--- a/lib/tasks/post-build.js
+++ b/lib/tasks/post-build.js
@@ -19,15 +19,30 @@ function createCommand(project, options) {
   });
 }
 
-module.exports = function(project, options) {
-  if (!options.rebuildOnChange) {
+module.exports = function(project, options, host, port, firstBuild) {
+  if (!options.rebuildOnChange && !firstBuild) {
     return function() {};
   }
 
+  if (!options.rebuildOnChange) {
+    var message = 'Updating config.xml to enable live reload';
+    var cordovaPath = path.join(project.root, 'cordova');
+    var contentSrcRegex = /(src=\")[\w\.\d\:\/]+(\")/;
+
+    require('./modify-xml')(message, cordovaPath, function(xml) {
+      var url = "http://" + host + ":" + port + "/index.html";
+      xml = this.xmlReplace(contentSrcRegex, url, xml);
+
+      return xml;
+    })();
+  }
+
   return function() {
+    ui.start(chalk.green('Building cordova project and launching emulator\n'));
     var rebuild = createCommand(project, options)();
 
     rebuild.then(function() {
+      ui.stop();
       ui.write(chalk.green('Cordova build successful.\n'));
     });
 

--- a/lib/tasks/post-build.js
+++ b/lib/tasks/post-build.js
@@ -38,7 +38,7 @@ module.exports = function(project, options, host, port, firstBuild) {
   }
 
   return function() {
-    ui.start(chalk.green('Building cordova project and launching emulator\n'));
+    ui.start(chalk.green('Building cordova project and launching emulator'));
     var rebuild = createCommand(project, options)();
 
     rebuild.then(function() {

--- a/lib/tasks/post-build.js
+++ b/lib/tasks/post-build.js
@@ -12,6 +12,8 @@ function createCommand(project, options) {
 
   if (options.emulate) {
     command += ' && cordova emulate ' + platform;
+  } else if (options.run) {
+    command += ' && cordova run --device ';
   }
 
   return runCommand(command, null, {
@@ -19,10 +21,13 @@ function createCommand(project, options) {
   });
 }
 
-module.exports = function(project, options, host, port, firstBuild) {
+module.exports = function(project, options, firstBuild) {
   if (!options.rebuildOnChange && !firstBuild) {
     return function() {};
   }
+
+  var host = options.liveReload.hostIP;
+  var port = options.liveReload.hostPort;
 
   if (!options.rebuildOnChange) {
     var message = 'Updating config.xml to enable live reload';

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -8,6 +8,9 @@ module.exports = {
     this.pleasantProgress.stop(true);
     this.pleasantProgress.start(msg)
   },
+  stop: function() {
+    this.pleasantProgress.stop(true);
+  },
   write: function(msg) {
     this.pleasantProgress.stream.write(msg);
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "pleasant-progress": "^1.0.1",
     "recursive-readdir": "^1.1.1",
     "rsvp": "^3.0.6",
-    "underscore.string": "^2.3.3"
+    "underscore.string": "^2.3.3",
+    "merge-defaults": "^0.2.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "2.0.0",


### PR DESCRIPTION
This PR implements fast live reloads. Fast because we're not rebuilding cordova every time, and instead relying on the Ember CLI's live reload mechanisms to reload app.

Of course, we still build it on the first time.
Changed docs to reflect the changes and instruct people how to enable it as well.

NOTE: I tested only on android, not sure this procedure works for iOS.