### PR TITLE
Add option to deploy to specific emulator target/image for platforms

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,14 @@ ENV.cordova = {
   // default: false
   emulate: true,
 
+  // Which emulated target to deploy to
+  //
+  // default: <system default>
+  emulateTarget: {
+    ios: "iPad-2",
+    android: "android-20"
+  }
+
   // Which platform to build and/or emulate
   //
   // default: 'ios'

--- a/lib/tasks/post-build.js
+++ b/lib/tasks/post-build.js
@@ -12,6 +12,12 @@ function createCommand(project, options) {
 
   if (options.emulate) {
     command += ' && cordova emulate ' + platform;
+
+    if (options.emulateTarget) {
+      if (options.emulateTarget[platform]) {
+        command += ' --target="' + options.emulateTarget[platform] + '"';
+      }
+    }
   }
 
   return runCommand(command, null, {


### PR DESCRIPTION
I e.g. wanted to test on iPad 2 instead of iPhone 6, and I didn’t want
to have to modify the Xcode project each time I want to switch the
emulated device/image. I hope this little addition is beneficial for
more than just me and I hadn’t just overlooked a simpler way to
accomplish this.

How did you guys solve this until now?